### PR TITLE
Switch from submodules to hugo modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/book"]
-	path = themes/book
-	url = https://github.com/alex-shpak/hugo-book

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the message box, type "Set site name" and hit enter.
 
 Congrats! You've just edited your site for the first time!
 
-You can write [markdown]() for blog posts or site pages - everything in the `content` folder is being rendered on your site. Look through that folder to see how things are used and structured (more in depth guides on this later, ofc). You can edit any files you please and see the effect.
+You can write [markdown](https://www.markdownguide.org/getting-started/) for blog posts or site pages - everything in the `content` folder is being rendered on your site. Look through that folder to see how things are used and structured (more in depth guides on this later, ofc). You can edit any files you please and see the effect.
 
 ## Local Workflow
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,16 @@
 # Update to your own settings for URL/title
 baseURL: https://platen-template.netlify.app/
 title: Platen Example
-theme: book
+# Google Analytics: uncomment and replace with your own code if you want to use this
+# googleAnalytics: G-123ABC456D
+
+module:
+  # Dev use only! Do not uncomment unless you're modifying a theme module!
+  # Only used in local testing; make sure to override the path to your own local copy
+  # replacements: 'github.com/platenio/hugo-platen -> C:\code\platen\themes\platen'
+  imports:
+    - path: github.com/platenio/hugo-platen
+    - path: github.com/alex-shpak/hugo-book
 
 # Book configuration
 disablePathToLower: true
@@ -64,7 +73,7 @@ params:
   # For backward compatibility you can set '*' to render all sections to menu. Acts same as '/'
   BookSection: docs
 
-  # Set source repository location.
+  # Set source repository location. Set this to YOUR repository!
   # Used for 'Last Modified' and 'Edit this page' links.
   BookRepo: https://github.com/platenio/book-template
 
@@ -78,7 +87,7 @@ params:
   # Enable "Edit this page" links for 'doc' page type.
   # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
   # Edit path must point to root directory of repo.
-  BookEditPath: edit/main/exampleSite
+  # BookEditPath: edit/main/exampleSite
 
   # Configure the date format used on the pages
   # - In git information

--- a/content/docs/picaroons/_index.md
+++ b/content/docs/picaroons/_index.md
@@ -1,6 +1,5 @@
 ---
 weight: 1
-bookFlatSection: true
 title: "Picaroons"
 ---
 
@@ -16,4 +15,4 @@ It currently includes lightweight rules for adjudication, character creation/adv
 
 You can also buy _Picaroons_ on itch, where it is itchfunding!
 
-<iframe frameborder="0" src="https://itch.io/embed/1167997?linkback=true" width="552" height="167"><a href="https://michaeltlombardi.itch.io/picaroons">Picaroons by Michael T Lombardi</a></iframe>
+<iframe title="Purchase Picaroons on Itch"frameborder="0" src="https://itch.io/embed/1167997?linkback=true" width="552" height="167"><a href="https://michaeltlombardi.itch.io/picaroons">Picaroons by Michael T Lombardi</a></iframe>

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/platenio/platen-template
+
+go 1.16
+
+require (
+	github.com/alex-shpak/hugo-book v0.0.0-20210907200533-6aef8ef1c776 // indirect
+	github.com/platenio/hugo-platen v0.0.0-20210908032145-33863a0ed75f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/alex-shpak/hugo-book v0.0.0-20210907200533-6aef8ef1c776 h1:wRep+NGTXIK1oNLj0gHKEAcYrdFD8+Qh+OfGx3Mzbrw=
+github.com/alex-shpak/hugo-book v0.0.0-20210907200533-6aef8ef1c776/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
+github.com/platenio/hugo-platen v0.0.0-20210908032145-33863a0ed75f h1:yfy8aysH2gu8AYOwV133aimIGxosqqjwDa8g3h4Eqlw=
+github.com/platenio/hugo-platen v0.0.0-20210908032145-33863a0ed75f/go.mod h1:oKKoHERB/TNznzstUQiRFuVaqMyk/l8jtUTXR1M+6bk=


### PR DESCRIPTION
This commit migrates from the old gitsubmodule method of themes to the
newer and less finicky hugo submodules. This reduces the number of tools
a user needs to know to get up and running.