### PR TITLE
(GH-3) Add deploy to netlify button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,20 @@
 
 To do this, you will need to create a user account for both [GitHub](https://github.com/join) and [Netlify](https://app.netlify.com/signup) if you don't already have one; if you create a GitHub account first, you can use that to login to Netlify.
 
-## Using this Template
+## Easy(ish) Mode
+
+Click this button to copy this template and deploy it to netlify:
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/platenio/platen-template)
+
+## Manual Mode
 
 1. Click [this link](https://github.com/platenio/platen-template/generate) to start the process for creating a new site from our template; this will give you your own copy to play with; give the project a name; if you don't want anyone else to see your work, select "Private" otherwise leave it to "Public" - ad a description if you want.
 2. On the page that automatically opens when you use the template, press the `.` period key - this will launch an online code editor and you won't have to have anyting installed or setup locally; if you'd prefer to try things locally, see [local workflow](#local-workflow) below.
 3. For now, there's nothing you _need_ to change, just leave this tab open.
 4. Go to [Netlify](https://app.netlify.com/) and login. From here, you're going to want to add your new project as a Netlify site - Netlify has a [blog on how to do so](https://netlify.com/blog/2016/10/27/a-step-by-step-guide-deploying-a-static-site-or-single-page-app/); it will involve authorizing Netlify to access GitHub on your behalf and then walk you through adding the site. You won't have to do anything beyond the defaults for this to work immediately.
+
+## Moving Forward
 
 At this point, you're able to start editing and changing things. The first thing you might want to do is change your site name; if you followed the blog above, it explains how to set a custom site name instead of using the random string it gives you.
 


### PR DESCRIPTION
This commit adds the deploy to netlify button to the readme and
reworks the headers to present this as the easier option.

Resolves #3