### PR TITLE
(MAINT) Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This commit adds dependabot to the project to help pick up upstream dependencies without requiring the users to explicitly know to do so.

I'm unclear if this will _actually_ work at the current time, so this may be removed in a future commit.