### PR TITLE
(MAINT) Rename home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Platen Example Site
+title: Home
 summary: >-
   This is an example site for digital books, built on Platen!
 ---


### PR DESCRIPTION
This change sets the home page title to `Home`, which fixes the problem of strange homepage tab naming for sites after using the template.