### PR TITLE
(MAINT) Add data file for `custom_css`

### DIFF
--- a/data/_params/platen/theme/variables/custom_css.yaml
+++ b/data/_params/platen/theme/variables/custom_css.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=http://platen.io/modules/platen/config/site/theme/config/schema.json#/properties/variables/properties/custom_css


### PR DESCRIPTION
This change adds the data file for the new `custom_css` config option in Platen.